### PR TITLE
Fixed the marks for the end-of-block on jumps and branches being set to late

### DIFF
--- a/arch_score7.c
+++ b/arch_score7.c
@@ -208,8 +208,8 @@ static bool disasm32(RAnalOp *r_op, uint32_t insn) {
                 case 0x03: OP_D(I("sdbbp"), rA);
                 case 0x04: {
                     r_op->type = rD == 3 ? R_ANAL_OP_TYPE_RET : R_ANAL_OP_TYPE_RJMP;
-                    OP_R(IBL("br", rB, cu), rA);
                     r_op->eob = true;
+                    OP_R(IBL("br", rB, cu), rA);
                 }
                 case 0x05: OP(I("pflush"));
                 case 0x06: OP_RM(I("alw"), rD, rA);
@@ -399,13 +399,13 @@ static bool disasm16(RAnalOp *r_op, uint16_t insn) {
                 case 0x3: OP_RR(I16("mv"), rD, rA);
                 case 0x4: {
                     r_op->type = rD == 3 ? R_ANAL_OP_TYPE_RET : R_ANAL_OP_TYPE_RJMP;
-                    OP_R(IBL16("br", rD, false), rA);
                     r_op->eob = true;
+                    OP_R(IBL16("br", rD, false), rA);
                 }
                 case 0x5: OP_R(IBL16("t", rD, false), rA);
                 case 0xC: {
-                    OP_R(IBL16("br", rD, true), rA);
                     r_op->eob = true;
+                    OP_R(IBL16("br", rD, true), rA);
                 }
                 default: OP_INVALID();
             }
@@ -453,12 +453,12 @@ static bool disasm16(RAnalOp *r_op, uint16_t insn) {
             }
         }
         case 0x3: {
-            OP_W(IL16("j", BIT_RANGE(insn, 0, 1)), (uint32_t)(r_op->addr & 0xFFFFF000) | (BIT_RANGE(insn, 1, 11) << 1));
             r_op->eob = true;
+            OP_W(IL16("j", BIT_RANGE(insn, 0, 1)), (uint32_t)(r_op->addr & 0xFFFFF000) | (BIT_RANGE(insn, 1, 11) << 1));
         }
         case 0x4: {
-            OP_W(IBL16("b", BIT_RANGE(insn, 8, 4), false), (uint32_t) r_op->addr + (sign_extend(BIT_RANGE(insn, 0, 8), 8) << 1));
             r_op->eob = true;
+            OP_W(IBL16("b", BIT_RANGE(insn, 8, 4), false), (uint32_t) r_op->addr + (sign_extend(BIT_RANGE(insn, 0, 8), 8) << 1));
         }
         case 0x5: OP_RD(I16("ldiu"), BIT_RANGE(insn, 8, 4), BIT_RANGE(insn, 0, 8));
         case 0x6: {


### PR DESCRIPTION
As per LiraNuna's the end of block tags were set after the OP_ macros. The macros have a return statement, so the end of blocks didn't do anything. This pull request moves the end of blocks to an earlier position. 